### PR TITLE
implement start quiz, and send question, and recv question

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -119,7 +119,7 @@ class DbHandler {
         }
     }
 
-    public async getQuestion(questionId: QuestionSchema) : Promise<QuestionSchema | null> {
+    public async getQuestion(questionId: string) : Promise<QuestionSchema | null> {
         try {
             const questionModel = getModelForClass(QuestionSchema);
             const question = questionModel.findById(questionId);
@@ -238,10 +238,10 @@ class DbInterface {
         }
     }
 
-    public async getQuestion(questionId: QuestionSchema) : Promise<QuestionSchema | null> {
+    public async getQuestion(questionId: string) : Promise<QuestionSchema | null> {
         try {
             const question = await this.db.getQuestion(questionId);
-            return  question;
+            return question;
         } catch (error) {
             console.error(`Error retrieving question by ID (${questionId}):`, error);
             return null;

--- a/src/io.ts
+++ b/src/io.ts
@@ -43,7 +43,7 @@ export const startIOServer = (httpServer: ServerType) => {
 
       const quiz = await db.getQuiz(DEFAULT_QUIZ);
       if (!quiz) {
-        console.error(`quiz not found! with id: ${DEFAULT_QUIZ}`);
+        console.error(`quiz not found with id: ${DEFAULT_QUIZ}`);
         return;
       }
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,11 +1,9 @@
 import { Server as IOServer } from "socket.io";
 import { ServerType } from "@hono/node-server/dist/types";
 import { WS_EVENTS } from "./events";
-import {DbInterface} from "./database/db";
 import { getQuestionDataForPlayer } from "./ioOperations";
 
 const DEFAULT_QUIZ = "65c0a4c2b07b34c123fc0b29"
-const db = new DbInterface();
 let recvQuestion = 0, playerCount = 0, questionIndex = 0;
 
 export const startIOServer = (httpServer: ServerType) => {

--- a/src/io.ts
+++ b/src/io.ts
@@ -2,7 +2,7 @@ import { Server as IOServer } from "socket.io";
 import { ServerType } from "@hono/node-server/dist/types";
 import { WS_EVENTS } from "./events";
 import {DbInterface} from "./database/db";
-import { sendQuestionToPlayers } from "./ioOperations";
+import { getQuestionDataForPlayer } from "./ioOperations";
 
 const DEFAULT_QUIZ = "65c0a4c2b07b34c123fc0b29"
 const db = new DbInterface();
@@ -40,14 +40,8 @@ export const startIOServer = (httpServer: ServerType) => {
 
     socket.on(WS_EVENTS.START_QUIZ, async (roomId: string) => {
       console.log(`${socket.id} started the game!`)
-
-      const quiz = await db.getQuiz(DEFAULT_QUIZ);
-      if (!quiz) {
-        console.error(`quiz not found with id: ${DEFAULT_QUIZ}`);
-        return;
-      }
-
-      sendQuestionToPlayers(roomId, io, quiz.Questions, questionIndex);
+      const data = await getQuestionDataForPlayer(roomId, DEFAULT_QUIZ, questionIndex);
+      io.to(roomId).emit(WS_EVENTS.NEW_QUESTION, data);
       questionIndex++;
     });
 

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -1,0 +1,16 @@
+import {WS_EVENTS} from "./events";
+import {DbInterface} from "./database/db";
+
+const db = new DbInterface();
+
+export function sendQuestionToPlayers(roomId: string, io, questions, questionIndex) {
+
+  db.getQuestion(questions[questionIndex]).then((question) => {
+    const data = {
+      question: question?.Question,
+      answers: Array.from(question?.PossibleAnswers.values())
+    }
+
+    io.to(roomId).emit(WS_EVENTS.NEW_QUESTION, data);
+  });
+}

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -1,16 +1,17 @@
-import {WS_EVENTS} from "./events";
 import {DbInterface} from "./database/db";
 
 const db = new DbInterface();
 
-export function sendQuestionToPlayers(roomId: string, io, questions, questionIndex) {
+export async function getQuestionDataForPlayer(roomId: string, quizId: string, questionIndex: number) {
+  const quiz = await db.getQuiz(quizId);
+  if (!quiz) {
+    console.error(`quiz not found with id: ${quizId}`);
+    return;
+  }
 
-  db.getQuestion(questions[questionIndex]).then((question) => {
-    const data = {
-      question: question?.Question,
-      answers: Array.from(question?.PossibleAnswers.values())
-    }
-
-    io.to(roomId).emit(WS_EVENTS.NEW_QUESTION, data);
-  });
+  const question = await db.getQuestion(quiz.Questions[questionIndex]);
+  return {
+    question: question?.Question,
+    answers: Array.from(question?.PossibleAnswers.values())
+  }
 }

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -10,8 +10,13 @@ export async function getQuestionDataForPlayer(roomId: string, quizId: string, q
   }
 
   const question = await db.getQuestion(quiz.Questions[questionIndex]);
+  if (!question) {
+    console.error(`question not found with id: ${quiz.Questions[questionIndex]}`);
+    return;
+  }
+
   return {
-    question: question?.Question,
+    question: question.Question,
     answers: Array.from(question?.PossibleAnswers.values())
   }
 }


### PR DESCRIPTION
Currently doesn't support join room logic, but start quiz, send timer and send question work. Currently using a hard coded variable to retrieve the default quiz to send to users.

## Testing
`git checkout `dummy-question-hack`` on the FE
go to `http://localhost:5173/room/1234/waiting` on one tab
on another tab go to `http://localhost:5173/join/1234` 
click start quiz on host view
the player view should change to display a question, and if you open console log, it'll show a start timer event has been triggered, when all players have received the question.


