### PR TITLE
Answer question

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -8,4 +8,5 @@ export const WS_EVENTS = {
     RECV_QUESTION: "recvQuestion",
     NEW_QUESTION: "newQuestion",
     SHOW_ANSWER: "showAnswer",
+    ANSWER_QUESTION: "answerQuestion"
 }

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,10 +1,16 @@
 import { Server as IOServer } from "socket.io";
 import { ServerType } from "@hono/node-server/dist/types";
 import { WS_EVENTS } from "./events";
-import { addPlayerToRoom, getQuestionDataForPlayer, setRoomToActive } from "./ioOperations";
+import {addPlayerToRoom, convertQuestionSchemaToData, getQuestionSchema, setRoomToActive} from "./ioOperations";
+import {QuestionSchema} from "./database/schema";
 
 const DEFAULT_QUIZ = "65c0a4c2b07b34c123fc0b29"
-let recvQuestion = 0, playerCount = 0, questionIndex = 0;
+const TIMEOUT = 31000
+
+let recvQuestion = 0, playerCount = 0, questionIndex = 0, recvAnswer = 0;
+let question: QuestionSchema;
+let playerScores = new Map<string, number>();
+let playerAnswerTimeout;
 
 export const startIOServer = (httpServer: ServerType) => {
   const io = new IOServer(httpServer, {
@@ -33,8 +39,10 @@ export const startIOServer = (httpServer: ServerType) => {
         console.log(`Player ${playerId} joined the room`);
         // add player to room in DB
         await addPlayerToRoom(roomId, playerId);
+        playerScores.set(playerId, 0);
         // let everyone else in the room know there is a new player
         io.to(roomId).emit(WS_EVENTS.NEW_PLAYER, { roomId, playerId });
+        playerCount++;
       }
     );
 
@@ -42,8 +50,14 @@ export const startIOServer = (httpServer: ServerType) => {
       console.log(`${socket.id} started the game!`);
       // set room in DB to active
       await setRoomToActive(roomId);
-      const data = await getQuestionDataForPlayer(roomId, DEFAULT_QUIZ, questionIndex);
+      // storing question so that we can send correct answer without repetitive DB calls
+      question = await getQuestionSchema(DEFAULT_QUIZ, questionIndex);
+      const data = convertQuestionSchemaToData(question);
       io.to(roomId).emit(WS_EVENTS.NEW_QUESTION, data);
+
+      playerAnswerTimeout = setTimeout(() => {
+        io.to(roomId).emit(WS_EVENTS.SHOW_ANSWER, question.CorrectAnswer);
+        }, TIMEOUT);
       questionIndex++;
     });
 
@@ -75,6 +89,19 @@ export const startIOServer = (httpServer: ServerType) => {
     socket.on(WS_EVENTS.SHOW_ANSWER, () => {
       console.log(`Show answer`);
     });
+
+    socket.on(WS_EVENTS.ANSWER_QUESTION, (roomId: string, playerId: string, answer: string) => {
+      recvAnswer++;
+      if (answer === question.CorrectAnswer) {
+        const currentScore = playerScores.get(playerId);
+        playerScores.set(playerId, currentScore + 1);
+      }
+
+      if (recvAnswer === playerCount) {
+        clearTimeout(playerAnswerTimeout);
+        io.to(roomId).emit(WS_EVENTS.SHOW_ANSWER, question.CorrectAnswer);
+      }
+      })
 
     socket.on("disconnect", () => {
       console.log(`User disconnected: ${socket.id}`);

--- a/src/io.ts
+++ b/src/io.ts
@@ -10,7 +10,7 @@ const TIMEOUT = 31000
 let recvQuestion = 0, playerCount = 0, questionIndex = 0, recvAnswer = 0;
 let question: QuestionSchema;
 let playerScores = new Map<string, number>();
-let playerAnswerTimeout;
+let playerAnswerTimeout: number;
 
 export const startIOServer = (httpServer: ServerType) => {
   const io = new IOServer(httpServer, {
@@ -50,6 +50,7 @@ export const startIOServer = (httpServer: ServerType) => {
       console.log(`${socket.id} started the game!`);
       // set room in DB to active
       await setRoomToActive(roomId);
+      questionIndex = 0;
       // storing question so that we can send correct answer without repetitive DB calls
       question = await getQuestionSchema(DEFAULT_QUIZ, questionIndex);
       const data = convertQuestionSchemaToData(question);
@@ -57,7 +58,7 @@ export const startIOServer = (httpServer: ServerType) => {
 
       playerAnswerTimeout = setTimeout(() => {
         io.to(roomId).emit(WS_EVENTS.SHOW_ANSWER, question.CorrectAnswer);
-        }, TIMEOUT);
+      }, TIMEOUT);
       questionIndex++;
     });
 
@@ -101,7 +102,7 @@ export const startIOServer = (httpServer: ServerType) => {
         clearTimeout(playerAnswerTimeout);
         io.to(roomId).emit(WS_EVENTS.SHOW_ANSWER, question.CorrectAnswer);
       }
-      })
+    })
 
     socket.on("disconnect", () => {
       console.log(`User disconnected: ${socket.id}`);

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -26,16 +26,6 @@ export function convertQuestionSchemaToData(question: QuestionSchema) {
   }
 }
 
-export async function getQuiz(quizId: string, questionIndex: number) {
-  const quiz = await db.getQuiz(quizId);
-  if (!quiz) {
-    console.error(`quiz not found with id: ${quizId}`);
-    return;
-  }
-
-  return await db.getQuestion(quiz.Questions[questionIndex]);
-}
-
 export async function setRoomToActive(roomId: string) {
   await db.updateRoomState(roomId, 'ACTIVE');
 }

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -1,8 +1,9 @@
 import {DbInterface} from "./database/db";
+import {QuestionSchema} from "./database/schema";
 
 const db = new DbInterface();
 
-export async function getQuestionDataForPlayer(roomId: string, quizId: string, questionIndex: number) {
+export async function getQuestionSchema(quizId: string, questionIndex: number) {
   const quiz = await db.getQuiz(quizId);
   if (!quiz) {
     console.error(`quiz not found with id: ${quizId}`);
@@ -15,10 +16,24 @@ export async function getQuestionDataForPlayer(roomId: string, quizId: string, q
     return;
   }
 
+  return question;
+}
+
+export function convertQuestionSchemaToData(question: QuestionSchema) {
   return {
     question: question.Question,
     answers: Array.from(question?.PossibleAnswers.values())
   }
+}
+
+export async function getQuiz(quizId: string, questionIndex: number) {
+  const quiz = await db.getQuiz(quizId);
+  if (!quiz) {
+    console.error(`quiz not found with id: ${quizId}`);
+    return;
+  }
+
+  return await db.getQuestion(quiz.Questions[questionIndex]);
 }
 
 export async function setRoomToActive(roomId: string) {


### PR DESCRIPTION
Back-end now supports answer question event entailing two things
1) if not all players answer the question, send SHOW_ANSWER event with correct answer (and potentially leaderboard as well) after 30 seconds
2) if all players answer the question before the 30 secs, send SHOW_ANSWER event

## Testing
`git checkout answer_question` on the FE
start host/players
to test case 1:
add log statements (or can add FE handler) and have at least one player not respond

to test case 2:
add log statements, and have all players answer before timeout

## FE changes

since we have diverged from the design doc, and to support case 2, the front-end must send WS_EVENT.ANSWER_Question like this
```
socket.emit(WS_EVENTS.ANSWER_QUESTION, roomId, playerId, answer);
```
answer in this case is the string value of the actual answer.
from here https://github.com/yesh0907/Toohak-FE/blob/answer_question/src/routes/player/JoinRoom.tsx#L54

