### PR TITLE
upon quiz completion, return leaderboard and player score

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -80,7 +80,7 @@ export const startIOServer = (httpServer: ServerType) => {
       questionIndex++;
     });
 
-    socket.on(WS_EVENTS.WAIT_FOR_QUIZ, async (roomId: string) => {
+    socket.on(WS_EVENTS.WAIT_FOR_QUIZ, async (roomId: string, playerId: string) => {
       recvWaitForQuiz++;
       if (recvWaitForQuiz === playerCount) {
         // get next question
@@ -98,8 +98,14 @@ export const startIOServer = (httpServer: ServerType) => {
         // no more questions, so it is the end of the quiz
         if (schema == null) {
           console.log('quiz done');
-          // TODO: include leaderboard results with event
-          io.to(roomId).emit(WS_EVENTS.QUIZ_COMPLETED);
+          // sort leaderboard by scores and get top 3
+          const leaderboard = Array.from(playerScores.entries()).sort((a, b) => b[1] - a[1]).slice(0, 3);
+          const playerScore = playerScores.get(playerId);
+          const data = {
+            'leaderboard': leaderboard,
+            'playerScore': playerScore,
+          }
+          io.to(roomId).emit(WS_EVENTS.QUIZ_COMPLETED, data);
         } else {
           console.log('next question');
           question = schema;

--- a/src/io.ts
+++ b/src/io.ts
@@ -101,7 +101,7 @@ export const startIOServer = (httpServer: ServerType) => {
           console.log('quiz done');
           // sort leaderboard by scores and get top 3
           const leaderboard = Array.from(playerScores.entries()).sort((a, b) => b[1] - a[1]).slice(0, 3);
-          const playerScore = playerScores.get(playerId);
+          const playerScore = playerScores.get(playerId) ?? 0;
           const data = {
             leaderboard, 
             playerScore,

--- a/src/io.ts
+++ b/src/io.ts
@@ -6,6 +6,7 @@ import {
   convertQuestionSchemaToData,
   getQuestionSchema,
   setRoomToActive,
+  setRoomToInactive,
 } from "./ioOperations";
 import { QuestionSchema } from "./database/schema";
 
@@ -102,9 +103,10 @@ export const startIOServer = (httpServer: ServerType) => {
           const leaderboard = Array.from(playerScores.entries()).sort((a, b) => b[1] - a[1]).slice(0, 3);
           const playerScore = playerScores.get(playerId);
           const data = {
-            'leaderboard': leaderboard,
-            'playerScore': playerScore,
+            leaderboard, 
+            playerScore,
           }
+          await setRoomToInactive(roomId);
           io.to(roomId).emit(WS_EVENTS.QUIZ_COMPLETED, data);
         } else {
           console.log('next question');

--- a/src/ioOperations.ts
+++ b/src/ioOperations.ts
@@ -47,6 +47,10 @@ export async function setRoomToActive(roomId: string) {
   await db.updateRoomState(roomId, 'ACTIVE');
 }
 
+export async function setRoomToInactive(roomId: string) {
+  await db.updateRoomState(roomId, "INACTIVE");
+}
+
 export async function addPlayerToRoom(roomId: string, playerId: string) {
   await db.appendPlayerIdToRoom(roomId, playerId);
 }


### PR DESCRIPTION
### Updates
If no more questions in quiz, BE sends `QUIZ_COMPLETED` event with the leaderboard (top 3 players) and the player score. 

### Testing 
Since quiz completed page has not been implemented, I printed object received from `QUIZ_COMPLETED` event containing leaderboard and player score to the log after answering all questions in the quiz.
![image](https://github.com/yesh0907/Toohak-BE/assets/42552095/8138487f-317b-4e34-b176-bb3c6a12196f)

### FE Changes
FE must send `player_id` with the `WAIT_FOR_QUIZ` socket event to be able to retrieve the player's score:
```
socket.emit(WS_EVENTS.WAIT_FOR_QUIZ, state$.roomId.get(), state$.player.id.get());
```
Line to change: https://github.com/yesh0907/Toohak-FE/blob/461ba0e3e30b8f8d73eaccf329c502d91d9203dd/src/routes/player/PlayQuiz.tsx#L73